### PR TITLE
Set JEKYLL_ENV to "production" for site build

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -827,7 +827,7 @@ params = CGI.parse(uri.query || "")
 
   def build_jekyll_site
     puts "Building jekyll site"
-    pipe("env PATH=$PATH bundle exec rake build 2>&1")
+    pipe("env PATH=$PATH JEKYLL_ENV=production bundle exec rake build 2>&1")
     unless $? == 0
       error "Failed to build site with jekyll."
     end


### PR DESCRIPTION
This avoids build problems related to symlinks for Jekyll 3.2.
In production mode, symlinks are treated differently.

This PR should fix failing builds as reported in https://github.com/jekyll/jekyll/issues/5144.
